### PR TITLE
[fix] TTS 생성 시 범위값 예외 처리

### DIFF
--- a/src/main/java/com/oreo/finalproject_5re5_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/global/exception/ErrorCode.java
@@ -43,7 +43,14 @@ public enum ErrorCode {
     // TTS ERROR 처리
     PROJECT_MISMATCH_ERROR(400, "요청하신 프로젝트를 소유하고 있지 않습니다."),
     VOICE_ENTITY_NOT_FOUND_ERROR(404, "해당 음성을 찾을 수 없습니다."),
-    TTS_SENTENCE_NOT_FOUND_ERROR(404, "해당 문장을 찾을 수 없습니다.");
+    TTS_SENTENCE_NOT_FOUND_ERROR(404, "해당 문장을 찾을 수 없습니다."),
+
+    // TTS 생성 ERROR 처리
+    TTS_MAKE_FAILED_ERROR(500, "TTS 생성에 실패했습니다."),
+    TTS_MAKE_INVALID_INPUT_VALUE_ERROR(400, "TTS 생성 입력값이 올바르지 않습니다."),
+    TTS_MAKE_INVALID_SPEED(400, "허용되지 않는 TTS 속도입니다."),
+    TTS_MAKE_INVALID_PITCH(400, "허용되지 않는 TTS 음높이입니다."),
+    TTS_MAKE_INVALID_VOLUME(400, "허용되지 않는 TTS 음량입니다.");
 
 
     private final String message;

--- a/src/main/java/com/oreo/finalproject_5re5_be/tts/client/AudioConfigGenerator.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/tts/client/AudioConfigGenerator.java
@@ -2,6 +2,8 @@ package com.oreo.finalproject_5re5_be.tts.client;
 
 import com.google.cloud.texttospeech.v1.AudioConfig;
 import com.google.cloud.texttospeech.v1.AudioEncoding;
+import com.oreo.finalproject_5re5_be.global.exception.ErrorCode;
+import com.oreo.finalproject_5re5_be.tts.exception.TtsMakeInvalidParamException;
 
 public class AudioConfigGenerator {
     // Google TTS AudioConfig 정책
@@ -24,9 +26,7 @@ public class AudioConfigGenerator {
     public static AudioConfig generate(double speed, double pitch, double volume) {
 
         // 1. 검증 통과 못하면 예외 던지기
-        if( !vaildSpeed(speed) || !validPitch(pitch) || !validVolume(volume) ) {
-            throw new IllegalArgumentException("잘못된 파라미터 값 입니다.");
-        }
+        checkParams(speed, pitch, volume);
 
         // 2. 객체 생성
         return AudioConfig.newBuilder()
@@ -40,12 +40,12 @@ public class AudioConfigGenerator {
 
     // 음성 속도 값 검증
     private static boolean vaildSpeed(double speed) {
-        return speed > MIN_SPEED && speed < MAX_SPEED;
+        return speed >= MIN_SPEED && speed <= MAX_SPEED;
     }
 
     // 피치 값 검증
     private static boolean validPitch(double pitch) {
-        return pitch > MIN_PITCH && pitch < MAX_PITCH;
+        return pitch >= MIN_PITCH && pitch <= MAX_PITCH;
     }
 
     // 볼륨 값 검증
@@ -53,4 +53,17 @@ public class AudioConfigGenerator {
         return volume > MIN_VOLUME && volume < MAX_VOLUME ;
     }
 
+
+    private static void checkParams(double speed, double pitch, double volume) {
+        if( !vaildSpeed(speed)) {
+            throw new TtsMakeInvalidParamException(ErrorCode.TTS_MAKE_INVALID_SPEED);
+        }
+
+        if( !validPitch(pitch)) {
+            throw new TtsMakeInvalidParamException(ErrorCode.TTS_MAKE_FAILED_ERROR);
+        }
+        if(!validVolume(volume) ) {
+            throw new TtsMakeInvalidParamException(ErrorCode.TTS_MAKE_INVALID_VOLUME);
+        }
+    }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/tts/exception/TtsMakeException.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/tts/exception/TtsMakeException.java
@@ -12,4 +12,12 @@ public class TtsMakeException extends BusinessException {
     public TtsMakeException(String message) {
         super(message, ErrorCode.INTERNAL_SERVER_ERROR);
     }
+
+    public TtsMakeException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+
+    public TtsMakeException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
 }

--- a/src/main/java/com/oreo/finalproject_5re5_be/tts/exception/TtsMakeInvalidParamException.java
+++ b/src/main/java/com/oreo/finalproject_5re5_be/tts/exception/TtsMakeInvalidParamException.java
@@ -1,0 +1,22 @@
+package com.oreo.finalproject_5re5_be.tts.exception;
+
+import com.oreo.finalproject_5re5_be.global.exception.ErrorCode;
+
+public class TtsMakeInvalidParamException extends TtsMakeException {
+
+  public TtsMakeInvalidParamException() {
+    super(ErrorCode.TTS_MAKE_INVALID_INPUT_VALUE_ERROR.getMessage(), ErrorCode.TTS_MAKE_INVALID_INPUT_VALUE_ERROR);
+  }
+
+  public TtsMakeInvalidParamException(String message) {
+    super(message, ErrorCode.TTS_MAKE_INVALID_INPUT_VALUE_ERROR);
+  }
+
+  public TtsMakeInvalidParamException(String message, ErrorCode errorCode) {
+    super(message, errorCode);
+  }
+
+  public TtsMakeInvalidParamException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+}


### PR DESCRIPTION
# 내용
TTS 생성 요청시 범위 값을 검사하는 로직에서 경계 값을 포함하지 않는 이슈가 있었습니다.
해당 부분을 경계값을 포함하여 처리하는 것으로 변경합니다.

0.25 < TTS 속도 < 4 에서  0.25 <= TTS 속도 <= 4 으로 변경

다른 값도 같이 변경하였으며 해당 부분에 대한 예외 처리도 진행하였습니다.